### PR TITLE
fix: Filter out expired items in ExpiringItemsWidget

### DIFF
--- a/app/Filament/Widgets/ExpiringItemsWidget.php
+++ b/app/Filament/Widgets/ExpiringItemsWidget.php
@@ -62,13 +62,14 @@ class ExpiringItemsWidget extends BaseWidget implements HasTable
         return Item::query()
             ->with(['location'])
             ->whereHas('batches', function ($q) {
-                $q->whereNotNull('expires_at');
+                $q->whereNotNull('expires_at')->where('expires_at', '>=', now());
             })
             ->addSelect([
                 'earliest_batch_expiration' => \App\Models\Batch::query()
                     ->select('expires_at')
                     ->whereColumn('item_id', 'items.id')
                     ->whereNotNull('expires_at')
+                    ->where('expires_at', '>=', now())
                     ->orderBy('expires_at')
                     ->limit(1),
             ]);

--- a/app/Providers/Filament/FreshguardPanelProvider.php
+++ b/app/Providers/Filament/FreshguardPanelProvider.php
@@ -42,9 +42,9 @@ class FreshguardPanelProvider extends PanelProvider
                 Dashboard::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\Filament\Widgets')
-             ->widgets([
-                 ExpiringItemsWidget::class,
-                 \App\Filament\Widgets\ExpiredItemsWidget::class,
+            ->widgets([
+                ExpiringItemsWidget::class,
+                \App\Filament\Widgets\ExpiredItemsWidget::class,
             ])
             ->middleware([
                 EncryptCookies::class,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the expiring items widget to correctly filter and display only items with at least one non-expired, future-dated batch. Items with exclusively expired batches or no batches are now properly excluded from the widget display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->