### PR TITLE
feat(widget): Add Recently Expired dashboard widget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,14 +14,13 @@ Build / Lint / Test (DDEV-aware)
 - Static analysis: `ddev composer phpstan` (2GB memory configured in composer script)
 - Run full test suite: `ddev composer test` (runs `php artisan test --exclude-group disabled`)
 - Run test coverage: `ddev composer test:coverage`
-- Run a single test file (example):
-  `ddev composer test -- --filter tests/Unit/ItemTest.php`
-- Run a single test class or method (examples):
-  `ddev composer test -- --filter "ItemTest::it_updates_quantity"`
-  or for Pest directly: `ddev ssh` then `vendor/bin/pest tests/Unit/ItemTest.php --filter="it updates quantity"`
+- Run a single test file/class/method (use artisan directly):
+  `ddev artisan test --exclude-group disabled --filter="SmokeTest"`
+  `ddev artisan test --exclude-group disabled --filter="ItemTest::it_updates_quantity"`
+  `ddev artisan test --exclude-group disabled tests/Unit/ItemTest.php`
 
 Composer scripts (quick reference)
-- `composer test` — run tests (wrapped by DDEV in workflows)
+- `ddev composer test` — run tests (wrapped by DDEV in workflows)
 - `composer pint` / `pint:dirty` — code formatting
 - `composer phpstan` — static analysis
 
@@ -99,7 +98,7 @@ When to ask questions
 
 Next steps for contributors
 1) Run formatting and static analysis: `ddev composer pint && ddev composer phpstan`.
-2) Run the single test you're working on with `ddev composer test -- --filter "YourTest::method"`.
+2) Run the single test you're working on with `ddev artisan test --exclude-group disabled --filter "YourTest::method"`.
 3) Open a small PR with focused changes and the three-checks green in CI.
 
 ===

--- a/app/Filament/Widgets/RecentlyExpired.php
+++ b/app/Filament/Widgets/RecentlyExpired.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Filament\Resources\Items\ItemResource;
+use App\Models\Batch;
+use BackedEnum;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Widget displaying recently expired product batches.
+ *
+ * Shows expired batches sorted by earliest expiration date first.
+ * Responsive design: progressively reveals columns on larger screens.
+ */
+class RecentlyExpired extends TableWidget
+{
+    protected int|string|array $columnSpan = 'full';
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCheckCircle;
+
+    public function getHeading(): string
+    {
+        return __('Recently Expired');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query($this->getTableQuery())
+            ->columns([
+                TextColumn::make('item.name')
+                    ->label(__('Item'))
+                    ->sortable(),
+                TextColumn::make('location.name')
+                    ->label(__('Location'))
+                    ->visibleFrom('lg'),
+                TextColumn::make('quantity')
+                    ->label(__('Quantity'))
+                    ->numeric()
+                    ->visibleFrom('sm'),
+                TextColumn::make('expires_at')
+                    ->label(__('Expiration Date'))
+                    ->date('d-m-Y')
+                    ->visibleFrom('md')
+            ])
+            ->recordUrl(fn (Batch $record): string => ItemResource::getUrl('edit', ['record' => $record->item]))
+            ->paginated(false)
+            ->emptyStateHeading(__('Congratulations, no expired items'))
+            ->emptyStateIcon(Heroicon::OutlinedCheckCircle);
+    }
+
+    /**
+     * Get the query for expired batches.
+     *
+     * @return Builder<Batch>
+     */
+    protected function getTableQuery(): Builder
+    {
+        return Batch::query()
+            ->with(['item', 'location'])
+            ->whereDate('expires_at', '<', today())
+            ->orderBy('expires_at', 'asc')
+            ->limit(5);
+    }
+}

--- a/app/Providers/Filament/FreshguardPanelProvider.php
+++ b/app/Providers/Filament/FreshguardPanelProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Providers\Filament;
 
-use App\Filament\Widgets\RecentlyExpired;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -43,7 +42,6 @@ class FreshguardPanelProvider extends PanelProvider
             ])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\Filament\Widgets')
             ->widgets([
-                RecentlyExpired::class,
             ])
             ->middleware([
                 EncryptCookies::class,

--- a/app/Providers/Filament/FreshguardPanelProvider.php
+++ b/app/Providers/Filament/FreshguardPanelProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Providers\Filament;
 
+use App\Filament\Widgets\RecentlyExpired;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -41,6 +42,9 @@ class FreshguardPanelProvider extends PanelProvider
                 Dashboard::class,
             ])
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\Filament\Widgets')
+            ->widgets([
+                RecentlyExpired::class,
+            ])
             ->middleware([
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,

--- a/tests/Feature/Filament/Widgets/RecentlyExpiredTest.php
+++ b/tests/Feature/Filament/Widgets/RecentlyExpiredTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Widgets\RecentlyExpired;
+use App\Models\Batch;
+use App\Models\Item;
+use App\Models\Location;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+
+use function Pest\Livewire\livewire;
+
+uses(RefreshDatabase::class);
+
+test('displays only expired batches sorted by earliest expiration', function (): void {
+    $item = Item::factory()->create();
+    $location = Location::factory()->create();
+
+    // Create expired batches (expired 1, 5, and 10 days ago)
+    $expiredBatch1 = Batch::factory()->create([
+        'item_id' => $item->id,
+        'location_id' => $location->id,
+        'expires_at' => Carbon::now()->subDays(1),
+        'quantity' => 10,
+    ]);
+
+    $expiredBatch2 = Batch::factory()->create([
+        'item_id' => $item->id,
+        'location_id' => $location->id,
+        'expires_at' => Carbon::now()->subDays(5),
+        'quantity' => 20,
+    ]);
+
+    $expiredBatch3 = Batch::factory()->create([
+        'item_id' => $item->id,
+        'location_id' => $location->id,
+        'expires_at' => Carbon::now()->subDays(10),
+        'quantity' => 30,
+    ]);
+
+    // Create non-expired batches (expires in future)
+    Batch::factory()->create([
+        'item_id' => $item->id,
+        'location_id' => $location->id,
+        'expires_at' => Carbon::now()->addDays(5),
+        'quantity' => 50,
+    ]);
+
+    Batch::factory()->create([
+        'item_id' => $item->id,
+        'location_id' => $location->id,
+        'expires_at' => Carbon::now()->addDays(10),
+        'quantity' => 60,
+    ]);
+
+    $expectedOrder = collect([$expiredBatch3, $expiredBatch2, $expiredBatch1])
+        ->sortBy('expires_at')
+        ->values();
+
+    livewire(RecentlyExpired::class)
+        ->assertSuccessful()
+        ->assertCountTableRecords(3)
+        ->assertCanSeeTableRecords($expectedOrder, inOrder: true);
+});

--- a/tests/Feature/Filament/Widgets/RecentlyExpiredTest.php
+++ b/tests/Feature/Filament/Widgets/RecentlyExpiredTest.php
@@ -6,12 +6,17 @@ use App\Filament\Widgets\RecentlyExpired;
 use App\Models\Batch;
 use App\Models\Item;
 use App\Models\Location;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 
 use function Pest\Livewire\livewire;
 
 uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->actingAs(User::factory()->create());
+});
 
 test('displays only expired batches sorted by earliest expiration', function (): void {
     $item = Item::factory()->create();
@@ -54,9 +59,7 @@ test('displays only expired batches sorted by earliest expiration', function ():
         'quantity' => 60,
     ]);
 
-    $expectedOrder = collect([$expiredBatch3, $expiredBatch2, $expiredBatch1])
-        ->sortBy('expires_at')
-        ->values();
+    $expectedOrder = collect([$expiredBatch3, $expiredBatch2, $expiredBatch1]);
 
     livewire(RecentlyExpired::class)
         ->assertSuccessful()


### PR DESCRIPTION
Add a responsive dashboard widget that displays expired product batches to help users quickly identify items that need attention.

The widget shows batches with expiration dates in the past, sorted by earliest expiration first (limited to 5 records). It uses a mobile-first responsive design:

- **Mobile**: Product name only
- **sm+**: Adds quantity  
- **md+**: Adds expiration date
- **lg+**: Adds location

Clicking any row navigates to the item's edit page. When no expired items exist, a congratulatory empty state is displayed.

**Implementation details:**
- Queries the Batch model with eager-loaded Item and Location relationships
- Filters by expires_at < today()
- No search functionality (keeps widget focused and simple)
- Includes comprehensive test coverage

This provides immediate visibility into inventory that requires attention without needing to navigate to the full batches table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dashboard widget showing recently expired product batches with item, location, quantity, and expiration date, linking to the related item.

* **Documentation**
  * Updated contributor test guidance and examples to run targeted tests via Artisan with improved exclude/filter options.

* **Tests**
  * Added feature tests covering the new expired-batch widget rendering and ordering.

* **Chores**
  * Minor provider registration tweak to widget discovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->