### PR TITLE
fix(tests): use deterministic names in item search tests

### DIFF
--- a/tests/Feature/Filament/Resources/Items/ItemResourceTest.php
+++ b/tests/Feature/Filament/Resources/Items/ItemResourceTest.php
@@ -23,7 +23,9 @@ test('can render page and see table records', function (): void {
 });
 
 test('can search items by name', function (): void {
-    $items = Item::factory()->count(5)->create();
+    $items = collect(['Alpha Item', 'Beta Item', 'Gamma Item', 'Delta Item', 'Epsilon Item'])
+        ->map(fn (string $name) => Item::factory()->create(['name' => $name]));
+
     $searchItem = $items->first();
 
     livewire(ManageItems::class)
@@ -43,7 +45,9 @@ test('can sort items by name', function (): void {
 });
 
 test('can search items by barcode', function (): void {
-    $items = Item::factory()->count(2)->create();
+    $items = collect(['0000000000001', '0000000000002'])
+        ->map(fn (string $barcode) => Item::factory()->create(['barcode' => $barcode]));
+
     $searchItem = $items->first();
 
     livewire(ManageItems::class)


### PR DESCRIPTION
Fix CI test failures in `ItemResourceTest` by using deterministic unique names and barcodes instead of random factory-generated values.

The tests `can search items by name` and `can search items by barcode` were failing in CI because they relied on random names/barcodes, which caused `assertCanNotSeeTableRecords` to fail when searching filtered out items were still rendered in the HTML.

## Summary
- Use explicit deterministic names (Alpha Item, Beta Item, etc.) for name search test
- Use explicit barcodes (0000000000001, 0000000000002) for barcode search test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for item search functionality by replacing randomly generated test data with explicit, deterministic values for name and barcode searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->