### PR TITLE
refactor: Reduce returns in QuickConsume methods

### DIFF
--- a/app/Filament/Pages/QuickConsume.php
+++ b/app/Filament/Pages/QuickConsume.php
@@ -54,7 +54,7 @@ class QuickConsume extends Page
 
     public function mount(): void
     {
-        $this->searchResults = new Collection();
+        $this->searchResults = new Collection;
 
         if (strlen($this->search) >= 2) {
             $this->performSearch();
@@ -64,7 +64,7 @@ class QuickConsume extends Page
     public function updatedSearch(): void
     {
         if (strlen($this->search) < 2) {
-            $this->searchResults = new Collection();
+            $this->searchResults = new Collection;
 
             return;
         }
@@ -178,19 +178,12 @@ class QuickConsume extends Page
      */
     private function getExpirationStatus(?Carbon $expiresAt): array
     {
-        if ($expiresAt === null) {
-            return ['icon' => Heroicon::OutlinedQuestionMarkCircle, 'color' => 'gray'];
-        }
-
-        if ($expiresAt->isPast()) {
-            return ['icon' => Heroicon::OutlinedExclamationTriangle, 'color' => 'danger'];
-        }
-
-        if ($expiresAt->diffInDays(now()) <= 7) {
-            return ['icon' => Heroicon::OutlinedClock, 'color' => 'warning'];
-        }
-
-        return ['icon' => Heroicon::OutlinedCheckCircle, 'color' => 'success'];
+        return match (true) {
+            $expiresAt === null => ['icon' => Heroicon::OutlinedQuestionMarkCircle, 'color' => 'gray'],
+            $expiresAt->isPast() => ['icon' => Heroicon::OutlinedExclamationTriangle, 'color' => 'danger'],
+            $expiresAt->diffInDays(now()) <= 7 => ['icon' => Heroicon::OutlinedClock, 'color' => 'warning'],
+            default => ['icon' => Heroicon::OutlinedCheckCircle, 'color' => 'success'],
+        };
     }
 
     public function consumeBatch(string $batchId): void
@@ -199,7 +192,28 @@ class QuickConsume extends Page
             return;
         }
 
-        $itemName = DB::transaction(function () use ($batchId): ?string {
+        $itemName = $this->decrementBatchQuantity($batchId);
+
+        if ($itemName === null) {
+            return;
+        }
+
+        Notification::make()
+            ->title(__('quick-consume.notification.consumed.title'))
+            ->body(__('quick-consume.notification.consumed.body', ['item' => $itemName]))
+            ->success()
+            ->send();
+
+        $this->performSearch();
+
+        // Clear cached schema to force infolist re-render with updated data
+        $this->cachedSchemas = [];
+        $this->isCachingSchemas = false;
+    }
+
+    private function decrementBatchQuantity(string $batchId): ?string
+    {
+        return DB::transaction(function () use ($batchId): ?string {
             $batch = Batch::query()
                 ->where('id', $batchId)
                 ->lockForUpdate()
@@ -220,21 +234,5 @@ class QuickConsume extends Page
 
             return $itemName;
         });
-
-        if ($itemName === null) {
-            return;
-        }
-
-        Notification::make()
-            ->title(__('quick-consume.notification.consumed.title'))
-            ->body(__('quick-consume.notification.consumed.body', ['item' => $itemName]))
-            ->success()
-            ->send();
-
-        $this->performSearch();
-
-        // Clear cached schema to force infolist re-render with updated data
-        $this->cachedSchemas = [];
-        $this->isCachingSchemas = false;
     }
 }

--- a/tests/Feature/Filament/Pages/QuickConsumeTest.php
+++ b/tests/Feature/Filament/Pages/QuickConsumeTest.php
@@ -342,3 +342,44 @@ test('consume batch does nothing when batch does not exist', function (): void {
         ->call('consumeBatch', $nonExistentId)
         ->assertNotNotified();
 });
+
+test('expiry date is formatted as day/month/year', function (): void {
+    $item = Item::factory()->create(['name' => 'Test Item']);
+    $location = Location::factory()->create();
+    $batch = Batch::factory()->create([
+        'item_id' => $item->id,
+        'location_id' => $location->id,
+        'quantity' => 5,
+        'expires_at' => '2026-12-25',
+    ]);
+
+    livewire(QuickConsume::class)
+        ->set('search', 'Test Item')
+        ->assertSuccessful()
+        ->assertSet('searchResults', function ($results) use ($batch): bool {
+            return $results->contains(
+                fn (Item $item): bool => $item->batches->contains(
+                    fn ($b): bool => $b->id === $batch->id && $b->expires_at->format('d/m/Y') === '25/12/2026'
+                )
+            );
+        });
+});
+
+test('consume batch does nothing when batch has zero quantity', function (): void {
+    $item = Item::factory()->create(['name' => 'Test Item']);
+    $location = Location::factory()->create();
+    $batch = Batch::factory()->create([
+        'item_id' => $item->id,
+        'location_id' => $location->id,
+        'quantity' => 0,
+        'expires_at' => now()->addDays(30),
+    ]);
+
+    livewire(QuickConsume::class)
+        ->set('search', 'Test Item')
+        ->call('consumeBatch', $batch->id)
+        ->assertNotNotified();
+
+    $batch->refresh();
+    expect($batch->quantity)->toBe(0);
+});


### PR DESCRIPTION

Replace if/return chains in `getExpirationStatus()` with a PHP 8 `match` expression, reducing from 4 return statements to 1.

Extract the database transaction logic from `consumeBatch()` into a new `decrementBatchQuantity()` method, splitting 4 return statements across two methods (each with ≤2 explicit returns).

This resolves two "brain-overload" Code Smell issues flagged on this page.

Adds tests for:
- Consuming a batch with zero quantity (edge case guard)
- Expiry date formatting in search results
