### PR TITLE
refactor(item-form): Extract barcode lookup logic into private methods

### DIFF
--- a/app/Filament/Resources/Items/Schemas/ItemForm.php
+++ b/app/Filament/Resources/Items/Schemas/ItemForm.php
@@ -88,6 +88,7 @@ class ItemForm
         }
 
         try {
+            /** @var array<string, mixed> $productData */
             $productData = OpenFoodFacts::barcode($state);
 
             if (empty($productData)) {

--- a/app/Filament/Resources/Items/Schemas/ItemForm.php
+++ b/app/Filament/Resources/Items/Schemas/ItemForm.php
@@ -88,7 +88,7 @@ class ItemForm
         }
 
         try {
-            /** @var array<string, mixed> $productData */
+            /** @var array{product_name?: string, generic_name?: string, categories_hierarchy?: array<int, string>|string|null} $productData */
             $productData = OpenFoodFacts::barcode($state);
 
             if (empty($productData)) {
@@ -110,7 +110,7 @@ class ItemForm
     }
 
     /**
-     * @param  array<string, mixed>  $productData
+     * @param  array{product_name?: string, generic_name?: string, categories_hierarchy?: array<int, string>|string|null}  $productData
      * @return array<int, string>
      */
     private static function populateFieldsFromProductData(Get $get, Set $set, array $productData): array

--- a/app/Filament/Resources/Items/Schemas/ItemForm.php
+++ b/app/Filament/Resources/Items/Schemas/ItemForm.php
@@ -39,72 +39,7 @@ class ItemForm
                                     ->label(__('Barcode'))
                                     ->live(onBlur: true)
                                     ->columnSpan(['sm' => 1, 'md' => 1])
-                                    ->afterStateUpdated(function (Get $get, Set $set, ?string $state, ?string $old): void {
-                                        // Only fetch if barcode changed and has a value
-                                        if (empty($state) || $state === $old) {
-                                            return;
-                                        }
-
-                                        try {
-                                            $productData = OpenFoodFacts::barcode($state);
-
-                                            if (empty($productData)) {
-                                                Notification::make()
-                                                    ->title(__('Product not found'))
-                                                    ->body(__('No product information found for this barcode.'))
-                                                    ->warning()
-                                                    ->send();
-
-                                                return;
-                                            }
-
-                                            $fieldsPopulated = [];
-
-                                            // Only populate if name is empty
-                                            if (empty($get('name')) && ! empty($productData['product_name'])) {
-                                                $set('name', $productData['product_name']);
-                                                $fieldsPopulated[] = __('name');
-                                            }
-
-                                            // Only populate if description is empty
-                                            if (empty($get('description')) && ! empty($productData['generic_name'])) {
-                                                $set('description', $productData['generic_name']);
-                                                $fieldsPopulated[] = __('description');
-                                            }
-
-                                            // Only populate tags if they are null/empty
-                                            $currentTags = $get('tags');
-                                            if (empty($currentTags) && ! empty($productData['categories_hierarchy'])) {
-                                                $tags = self::extractTagsFromCategories($productData['categories_hierarchy']);
-
-                                                if (! empty($tags)) {
-                                                    $set('tags', $tags);
-                                                    $fieldsPopulated[] = __('tags');
-                                                }
-                                            }
-
-                                            // Show success notification with populated fields
-                                            if (! empty($fieldsPopulated)) {
-                                                Notification::make()
-                                                    ->title(__('Product data loaded'))
-                                                    ->body(__('Populated: :fields', ['fields' => implode(', ', $fieldsPopulated)]))
-                                                    ->success()
-                                                    ->send();
-                                            } else {
-                                                Notification::make()
-                                                    ->title(__('Product found'))
-                                                    ->body(__('No empty fields to populate.'))
-                                                    ->info()
-                                                    ->send();
-                                            }
-                                        } catch (\Exception $e) {
-                                            Log::warning('Error fetching product data for barcode', [
-                                                'barcode' => $state,
-                                                'error' => $e->getMessage(),
-                                                'exception' => get_class($e),
-                                            ]);
-                                        }
-                                    }),
+                                    ->afterStateUpdated(static fn (Get $get, Set $set, ?string $state, ?string $old) => self::handleBarcodeLookup($get, $set, $state, $old)),
                             ]),
                         Textarea::make('description')
                             ->maxLength(1000)
@@ -129,7 +64,6 @@ class ItemForm
                                 TagsInput::make('tags')
                                     ->label(__('Tags'))
                                     ->suggestions(function (): array {
-                                        // Get all existing tags from all items
                                         return Item::query()
                                             ->whereNotNull('tags')
                                             ->pluck('tags')
@@ -145,6 +79,95 @@ class ItemForm
                     ])
                     ->compact(),
             ]);
+    }
+
+    private static function handleBarcodeLookup(Get $get, Set $set, ?string $state, ?string $old): void
+    {
+        if (empty($state) || $state === $old) {
+            return;
+        }
+
+        try {
+            $productData = OpenFoodFacts::barcode($state);
+
+            if (empty($productData)) {
+                self::notifyProductNotFound();
+
+                return;
+            }
+
+            $fieldsPopulated = self::populateFieldsFromProductData($get, $set, $productData);
+
+            self::notifyFieldsPopulated($fieldsPopulated);
+        } catch (\Exception $e) {
+            Log::warning('Error fetching product data for barcode', [
+                'barcode' => $state,
+                'error' => $e->getMessage(),
+                'exception' => get_class($e),
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $productData
+     * @return array<int, string>
+     */
+    private static function populateFieldsFromProductData(Get $get, Set $set, array $productData): array
+    {
+        $fieldsPopulated = [];
+
+        if (empty($get('name')) && ! empty($productData['product_name'])) {
+            $set('name', $productData['product_name']);
+            $fieldsPopulated[] = __('name');
+        }
+
+        if (empty($get('description')) && ! empty($productData['generic_name'])) {
+            $set('description', $productData['generic_name']);
+            $fieldsPopulated[] = __('description');
+        }
+
+        $currentTags = $get('tags');
+        if (empty($currentTags) && ! empty($productData['categories_hierarchy'])) {
+            $tags = self::extractTagsFromCategories($productData['categories_hierarchy']);
+
+            if (! empty($tags)) {
+                $set('tags', $tags);
+                $fieldsPopulated[] = __('tags');
+            }
+        }
+
+        return $fieldsPopulated;
+    }
+
+    private static function notifyProductNotFound(): void
+    {
+        Notification::make()
+            ->title(__('Product not found'))
+            ->body(__('No product information found for this barcode.'))
+            ->warning()
+            ->send();
+    }
+
+    /**
+     * @param  array<int, string>  $fieldsPopulated
+     */
+    private static function notifyFieldsPopulated(array $fieldsPopulated): void
+    {
+        if (! empty($fieldsPopulated)) {
+            Notification::make()
+                ->title(__('Product data loaded'))
+                ->body(__('Populated: :fields', ['fields' => implode(', ', $fieldsPopulated)]))
+                ->success()
+                ->send();
+
+            return;
+        }
+
+        Notification::make()
+            ->title(__('Product found'))
+            ->body(__('No empty fields to populate.'))
+            ->info()
+            ->send();
     }
 
     /**

--- a/app/Filament/Resources/Users/Actions/ToggleRegistrationsAction.php
+++ b/app/Filament/Resources/Users/Actions/ToggleRegistrationsAction.php
@@ -38,7 +38,7 @@ class ToggleRegistrationsAction
 
                 return $user instanceof User && $user->isAdmin();
             })
-            ->action(function (Action $action): void {
+            ->action(function (): void {
                 $currentStatus = config('freshguard.registrations_enabled');
                 $newStatus = ! $currentStatus;
 

--- a/tests/Feature/Filament/Resources/Items/ItemFormSchemaTest.php
+++ b/tests/Feature/Filament/Resources/Items/ItemFormSchemaTest.php
@@ -4,12 +4,18 @@ declare(strict_types=1);
 
 use App\Filament\Resources\Items\Pages\CreateItem;
 use App\Models\Item;
+use App\Models\User;
+use Filament\Forms\Components\TagsInput;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use OpenFoodFacts\Laravel\Facades\OpenFoodFacts;
 
 use function Pest\Livewire\livewire;
 
 uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->actingAs(User::factory()->create());
+});
 
 test('barcode lookup populates empty fields from product data', function (): void {
     OpenFoodFacts::shouldReceive('barcode')
@@ -142,7 +148,11 @@ test('tags input shows suggestions from existing items', function (): void {
 
     livewire(CreateItem::class)
         ->assertOk()
-        ->assertFormFieldExists('tags');
+        ->assertFormFieldExists('tags', function (TagsInput $field): bool {
+            expect($field->getSuggestions())->toBe(['Dairy', 'Healthy', 'Promotion', 'Snacks']);
+
+            return true;
+        });
 });
 
 test('tags input suggestions empty when no items have tags', function (): void {
@@ -150,7 +160,11 @@ test('tags input suggestions empty when no items have tags', function (): void {
 
     livewire(CreateItem::class)
         ->assertOk()
-        ->assertFormFieldExists('tags');
+        ->assertFormFieldExists('tags', function (TagsInput $field): bool {
+            expect($field->getSuggestions())->toBe([]);
+
+            return true;
+        });
 });
 
 test('barcode lookup handles categories with non-array value', function (): void {

--- a/tests/Feature/Filament/Resources/Items/ItemFormSchemaTest.php
+++ b/tests/Feature/Filament/Resources/Items/ItemFormSchemaTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\Items\Pages\CreateItem;
+use App\Models\Item;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use OpenFoodFacts\Laravel\Facades\OpenFoodFacts;
+
+use function Pest\Livewire\livewire;
+
+uses(RefreshDatabase::class);
+
+test('barcode lookup populates empty fields from product data', function (): void {
+    OpenFoodFacts::shouldReceive('barcode')
+        ->with('3017620422003')
+        ->once()
+        ->andReturn([
+            'product_name' => 'Nutella',
+            'generic_name' => 'Hazelnut spread',
+            'categories_hierarchy' => ['en:spreads', 'en:hazelnut-spreads'],
+        ]);
+
+    livewire(CreateItem::class)
+        ->fillForm([
+            'name' => null,
+            'description' => null,
+            'tags' => [],
+        ])
+        ->set('data.barcode', '3017620422003')
+        ->assertSchemaStateSet([
+            'name' => 'Nutella',
+            'description' => 'Hazelnut spread',
+            'tags' => ['spreads', 'hazelnut-spreads'],
+        ])
+        ->assertNotified();
+});
+
+test('barcode lookup does not override existing field values', function (): void {
+    OpenFoodFacts::shouldReceive('barcode')
+        ->with('3017620422003')
+        ->once()
+        ->andReturn([
+            'product_name' => 'Nutella',
+            'generic_name' => 'Hazelnut spread',
+            'categories_hierarchy' => ['en:spreads', 'en:hazelnut-spreads'],
+        ]);
+
+    livewire(CreateItem::class)
+        ->fillForm([
+            'name' => 'My Custom Name',
+            'description' => null,
+            'tags' => [],
+        ])
+        ->set('data.barcode', '3017620422003')
+        ->assertSchemaStateSet([
+            'name' => 'My Custom Name',
+            'description' => 'Hazelnut spread',
+            'tags' => ['spreads', 'hazelnut-spreads'],
+        ])
+        ->assertNotified();
+});
+
+test('barcode lookup shows warning when product not found', function (): void {
+    OpenFoodFacts::shouldReceive('barcode')
+        ->with('0000000000000')
+        ->once()
+        ->andReturn([]);
+
+    livewire(CreateItem::class)
+        ->fillForm([
+            'name' => null,
+            'description' => null,
+        ])
+        ->set('data.barcode', '0000000000000')
+        ->assertNotified();
+});
+
+test('barcode lookup shows info when all fields already populated', function (): void {
+    OpenFoodFacts::shouldReceive('barcode')
+        ->with('3017620422003')
+        ->once()
+        ->andReturn([
+            'product_name' => 'Nutella',
+            'generic_name' => 'Hazelnut spread',
+            'categories_hierarchy' => ['en:spreads', 'en:hazelnut-spreads'],
+        ]);
+
+    livewire(CreateItem::class)
+        ->fillForm([
+            'name' => 'Pre-filled Name',
+            'description' => 'Pre-filled Description',
+            'tags' => ['existing-tag'],
+        ])
+        ->set('data.barcode', '3017620422003')
+        ->assertNotified();
+});
+
+test('barcode lookup ignores empty state that equals old value', function (): void {
+    livewire(CreateItem::class)
+        ->fillForm([
+            'name' => null,
+            'description' => null,
+        ])
+        ->set('data.barcode', null)
+        ->assertNotNotified();
+});
+
+test('barcode lookup handles exception gracefully', function (): void {
+    OpenFoodFacts::shouldReceive('barcode')
+        ->with('3017620422003')
+        ->once()
+        ->andThrow(new RuntimeException('API unavailable'));
+
+    livewire(CreateItem::class)
+        ->fillForm([
+            'name' => null,
+            'description' => null,
+        ])
+        ->set('data.barcode', '3017620422003')
+        ->assertNotNotified();
+});
+
+test('barcode lookup handles exception with custom exception type', function (): void {
+    OpenFoodFacts::shouldReceive('barcode')
+        ->with('3017620422003')
+        ->once()
+        ->andThrow(new Exception('Connection timeout'));
+
+    livewire(CreateItem::class)
+        ->fillForm([
+            'name' => null,
+            'description' => null,
+        ])
+        ->set('data.barcode', '3017620422003')
+        ->assertNotNotified();
+});
+
+test('tags input shows suggestions from existing items', function (): void {
+    Item::factory()->create(['tags' => ['Promotion', 'Healthy', 'Dairy']]);
+    Item::factory()->create(['tags' => ['Promotion', 'Snacks']]);
+
+    livewire(CreateItem::class)
+        ->assertOk()
+        ->assertFormFieldExists('tags');
+});
+
+test('tags input suggestions empty when no items have tags', function (): void {
+    Item::factory()->create(['tags' => null]);
+
+    livewire(CreateItem::class)
+        ->assertOk()
+        ->assertFormFieldExists('tags');
+});
+
+test('barcode lookup handles categories with non-array value', function (): void {
+    OpenFoodFacts::shouldReceive('barcode')
+        ->with('3017620422003')
+        ->once()
+        ->andReturn([
+            'product_name' => 'Nutella',
+            'generic_name' => 'Hazelnut spread',
+            'categories_hierarchy' => 'not-an-array',
+        ]);
+
+    livewire(CreateItem::class)
+        ->fillForm([
+            'name' => null,
+            'description' => null,
+            'tags' => [],
+        ])
+        ->set('data.barcode', '3017620422003')
+        ->assertSchemaStateSet([
+            'name' => 'Nutella',
+            'description' => 'Hazelnut spread',
+            'tags' => [],
+        ])
+        ->assertNotified();
+});


### PR DESCRIPTION

Extracts the inline barcode lookup callback from the barcode form field into dedicated private methods (`handleBarcodeLookup`, `populateFieldsFromProductData`, `notifyProductNotFound`, `notifyFieldsPopulated`).

This improves readability by reducing the barcode field configuration to a single line, and makes each unit of behavior independently testable.

No behavioral change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Barcode entry now automatically fills in item details from product lookup results when matching data is available.
  * Existing values are preserved, so manually entered fields won’t be overwritten.
  * Users now get clearer notifications for product found, product loaded, or product not found states.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->