### PR TITLE
test(filament): Use SQL ordering in sort assertions

### DIFF
--- a/tests/Feature/Filament/Resources/Items/ItemResourceTest.php
+++ b/tests/Feature/Filament/Resources/Items/ItemResourceTest.php
@@ -35,13 +35,33 @@ test('can search items by name', function (): void {
 });
 
 test('can sort items by name', function (): void {
-    $items = Item::factory()->count(3)->create();
+    $items = Item::factory()
+        ->count(4)
+        ->sequence(
+            ['name' => 'alpha item'],
+            ['name' => 'Beta item'],
+            ['name' => 'Same item'],
+            ['name' => 'Same item'],
+        )
+        ->create();
+
+    $itemsAscending = Item::query()
+        ->whereKey($items->modelKeys())
+        ->orderBy('name')
+        ->orderBy('id')
+        ->get();
+
+    $itemsDescending = Item::query()
+        ->whereKey($items->modelKeys())
+        ->orderByDesc('name')
+        ->orderByDesc('id')
+        ->get();
 
     livewire(ManageItems::class)
         ->sortTable('name')
-        ->assertCanSeeTableRecords($items->sortBy('name'), inOrder: true)
+        ->assertCanSeeTableRecords($itemsAscending, inOrder: true)
         ->sortTable('name', 'desc')
-        ->assertCanSeeTableRecords($items->sortByDesc('name'), inOrder: true);
+        ->assertCanSeeTableRecords($itemsDescending, inOrder: true);
 });
 
 test('can search items by barcode', function (): void {

--- a/tests/Feature/Filament/Resources/Users/UserResourceTest.php
+++ b/tests/Feature/Filament/Resources/Users/UserResourceTest.php
@@ -44,23 +44,64 @@ test('can search users by email', function (): void {
 });
 
 test('can sort users by name', function (): void {
-    $users = User::factory()->count(3)->create();
+    $users = User::factory()
+        ->count(4)
+        ->sequence(
+            ['name' => 'alpha user'],
+            ['name' => 'Beta user'],
+            ['name' => 'Same user'],
+            ['name' => 'Same user'],
+        )
+        ->create();
+
+    $usersAscending = User::query()
+        ->whereKey($users->modelKeys())
+        ->orderBy('name')
+        ->orderBy('id')
+        ->get();
+
+    $usersDescending = User::query()
+        ->whereKey($users->modelKeys())
+        ->orderByDesc('name')
+        ->orderBy('id')
+        ->get();
 
     livewire(ManageUsers::class)
         ->sortTable('name')
-        ->assertCanSeeTableRecords($users->sortBy('name'), inOrder: true)
+        ->assertCanSeeTableRecords($usersAscending, inOrder: true)
         ->sortTable('name', 'desc')
-        ->assertCanSeeTableRecords($users->sortByDesc('name'), inOrder: true);
+        ->assertCanSeeTableRecords($usersDescending, inOrder: true);
 });
 
 test('can sort users by email', function (): void {
-    $users = User::factory()->count(3)->create();
+    $users = User::factory()
+        ->count(3)
+        ->sequence(
+            ['email' => 'zulu@example.test'],
+            ['email' => 'alpha@example.test'],
+            ['email' => 'Beta@example.test'],
+        )
+        ->create();
+
+    $usersAscending = User::query()
+        ->whereKey($users->modelKeys())
+        ->orderBy('email')
+        ->orderBy('name')
+        ->orderBy('id')
+        ->get();
+
+    $usersDescending = User::query()
+        ->whereKey($users->modelKeys())
+        ->orderByDesc('email')
+        ->orderBy('name')
+        ->orderBy('id')
+        ->get();
 
     livewire(ManageUsers::class)
         ->sortTable('email')
-        ->assertCanSeeTableRecords($users->sortBy('email'), inOrder: true)
+        ->assertCanSeeTableRecords($usersAscending, inOrder: true)
         ->sortTable('email', 'desc')
-        ->assertCanSeeTableRecords($users->sortByDesc('email'), inOrder: true);
+        ->assertCanSeeTableRecords($usersDescending, inOrder: true);
 });
 
 test('can sort users by email verified status', function (): void {


### PR DESCRIPTION
Replace PHP collection sorting in the Item and User Filament tests with scoped Eloquent queries.

Filament delegates table sorting to the database, so PHP `sortBy()` could produce a different expected order than MariaDB's collation. The new fixtures include mixed-case and duplicate values, and the expected queries mirror Filament's default and primary-key tie-breaking behavior.

This only improves test correctness; production table behavior is unchanged.

Validated with Pint and both affected feature-test files: 31 tests passed with 169 assertions.

Closes #373


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for item and user table sorting.
  * Added deterministic scenarios for duplicate names and varied email values.
  * Verified consistent ascending and descending sort results, including tie-breaking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->