### PR TITLE
docs: Align docs and agent guidance with Laravel 13 / Filament-first architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ This application is a Laravel application and its main Laravel ecosystems packag
 
 - php - 8.5
 - filament/filament (FILAMENT) - v5
-- laravel/framework (LARAVEL) - v12
+- laravel/framework (LARAVEL) - v13
 - laravel/prompts (PROMPTS) - v0
 - livewire/livewire (LIVEWIRE) - v4
 - larastan/larastan (LARASTAN) - v3
@@ -252,16 +252,16 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 
 - If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `composer run dev`.
 
-=== laravel/v12 rules ===
+=== laravel/v13 rules ===
 
-# Laravel 12
+# Laravel 13
 
 - CRITICAL: ALWAYS use `search-docs` tool for version-specific Laravel documentation and updated code examples.
 - Since Laravel 11, Laravel has a new streamlined file structure which this project uses.
 
-## Laravel 12 Structure
+## Laravel 13 Structure
 
-- In Laravel 12, middleware are no longer registered in `app/Http/Kernel.php`.
+- In Laravel 11+, middleware are no longer registered in `app/Http/Kernel.php`.
 - Middleware are configured declaratively in `bootstrap/app.php` using `Application::configure()->withMiddleware()`.
 - `bootstrap/app.php` is the file to register middleware, exceptions, and routing files.
 - `bootstrap/providers.php` contains application specific service providers.
@@ -271,7 +271,7 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 ## Database
 
 - When modifying a column, the migration must include all of the attributes that were previously defined on the column. Otherwise, they will be dropped and lost.
-- Laravel 12 allows limiting eagerly loaded records natively, without external packages: `$query->latest()->limit(10);`.
+- Laravel 11+ allows limiting eagerly loaded records natively, without external packages: `$query->latest()->limit(10);`.
 
 ### Models
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ FreshGuard is built with modern, battle-tested technologies designed for reliabi
 
 ### Core Technologies
 
-- **Framework**: Laravel 12 - A powerful PHP framework with expressive syntax and elegant solutions
+- **Framework**: Laravel 13 - A powerful PHP framework with expressive syntax and elegant solutions
 - **Frontend**: Tailwind CSS v4 - Utility-first CSS for responsive, beautiful interfaces
 - **Admin Panel**: Filament - A beautiful TALL stack admin panel built on Laravel
 - **Database**: MariaDB with support for other production databases
@@ -36,13 +36,13 @@ FreshGuard is built with modern, battle-tested technologies designed for reliabi
 
 ### Architecture Highlights
 
-- **Eloquent ORM** - Elegant database interactions with intuitive relationships
-- **Form Requests** - Powerful validation layer for data integrity
-- **Service Layer** - Clean separation of concerns with dependency injection
+- **Filament v5 Admin Panel** - The entire UI is a Filament resource-driven admin panel under `app/Filament/Resources/{Items,Locations,Users}` (no separate front-end app or REST API)
+- **Livewire v4 + Schema-Driven Forms/Tables** - Forms and tables are defined in PHP via `app/Filament/Resources/*/Schemas` and `app/Filament/Resources/*/Tables`, powered by Livewire and Alpine.js
+- **Eloquent ORM + UUID Models** - Domain and persistence live in `app/Models/{Batch,Item,Location,User}`, using UUID primary keys (`HasUuids`)
+- **Batch-Centric Inventory** - A `Batch` groups `Item` records by purchase or storage date for batch-level tracking
+- **Form Request Validation** - Validation is enforced through `app/Http/Requests/*` backing the Filament schemas
 - **PSR-12 Compliance** - Industry-standard PHP coding standards
 - **PHPStan Level 10** - Strict static analysis for maximum type safety
-- **RESTful Design** - API-first architecture for flexibility and extensibility
-- **Modular Structure** - Clear separation between Models, Controllers, and Requests
 
 ### Data Models
 
@@ -146,7 +146,7 @@ MAIL_MAILER=log
 MAIL_LOG_CHANNEL=stack
 ```
 
-Refer to the [Laravel Mail Documentation](https://laravel.com/docs/12.x/mail) for detailed configuration instructions for your chosen email provider.
+Refer to the [Laravel Mail Documentation](https://laravel.com/docs/13.x/mail) for detailed configuration instructions for your chosen email provider.
 
 ### User Registration Control
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "$schema": "https://getcomposer.org/schema.json",
     "name": "marcelorodrigo/freshguard",
     "type": "project",
-    "description": "The skeleton application for the Laravel framework.",
+    "description": "FreshGuard — intelligent home stock inventory management.",
     "keywords": ["laravel", "framework"],
     "license": "MIT",
     "require": {

--- a/docs/COOLIFY_DEPLOYMENT.md
+++ b/docs/COOLIFY_DEPLOYMENT.md
@@ -429,7 +429,7 @@ Include in your backup strategy.
 ## Additional Resources
 
 - **Coolify Docs**: https://coolify.io/docs
-- **Laravel Docs**: https://laravel.com/docs/12.x
+- **Laravel Docs**: https://laravel.com/docs/13.x
 - **serversideup/php Image**: https://docs.serversideup.io/open-source/docker-php/
 - **FreshGuard GitHub**: https://github.com/marcelorodrigo/freshguard
 


### PR DESCRIPTION
Update all stale Laravel 12 references and replace architecture claims that describe a REST API-first, service-layer structure that doesn't exist in this codebase.

**What changed:**

- **README.md** — Rewrote the Architecture Highlights section to map every claim to an actual implemented subsystem path (`app/Filament/Resources/*`, `*/Schemas`+*`/Tables`, `app/Models/{Batch,Item,Location,User}`). Bumped framework version label and docs links to Laravel 13.
- **AGENTS.md** — Updated package version table (LARAVEL v12→v13), renamed the `laravel/v12 rules` section to `laravel/v13 rules`, and corrected body references. PHPUnit 12 references left intact per acceptance criteria.
- **docs/COOLIFY_DEPLOYMENT.md** — Updated Laravel docs link to `13.x`.
- **composer.json** — Fixed stale skeleton-app description to reflect the actual project.

**Why:**

FreshGuard uses Laravel 13 and a Filament/Livewire, schema-driven, Eloquent, batch-centric design, but contributors were reading Laravel 12 documentation and expecting a REST API/service-layer structure that does not exist. This caused confusion during setup and development.

Closes #375