### PR TITLE
ci(workflows): Enforce Laravel Pint formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
         run: npm install
       - name: Generating assets
         run: npm run build
+      - name: Pint (code style check)
+        run: vendor/bin/pint --test --parallel
       - name: PHPStan
         run: composer phpstan
       - name: Execute tests


### PR DESCRIPTION

Add a check-only Pint step (`vendor/bin/pint --test --parallel`) before PHPStan in the CI workflow.

The repository documented this contract in AGENTS.md (pint → phpstan → test)
but the workflow never ran Pint, allowing unformatted PHP to reach later stages.

The `--test` flag reports differences without rewriting the checkout, and
names every file that needs formatting. Pint's default Laravel preset is used
(no new config file) — matches the local `composer pint` behavior exactly.

Closes #370.
