### PR TITLE
build: Pin Node.js 24 LTS and enforce npm ci across all environments

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -98,7 +98,7 @@ web_extra_exposed_ports:
 # Alternatively, an explicit Composer version may be specified, for example "2.2.18".
 # To reinstall Composer after the image was built, run "ddev debug rebuild".
 
-# nodejs_version: "22"
+nodejs_version: "24"
 # change from the default system Node.js version to any other version.
 # See https://docs.ddev.com/en/stable/users/configuration/config/#nodejs_version for more information
 # and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           node-version: 24
           cache: 'npm'
       - name: Installing Node dependencies
-        run: npm install
+        run: npm ci
       - name: Generating assets
         run: npm run build
       - name: Pint (code style check)

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ############################################
 # Stage 1: Build frontend assets
 ############################################
-FROM node:26-alpine AS assets
+FROM node:24-alpine AS assets
 WORKDIR /app
 
 # Copy package files for better layer caching

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ FreshGuard is built with modern, battle-tested technologies designed for reliabi
 
 - PHP 8.5+
 - Composer
-- Node.js & npm (for frontend assets)
+- Node.js 24 LTS & npm 10+ (for frontend assets)
 - MariaDB
 
 ### Installation

--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
     "$schema": "https://json.schemastore.org/package.json",
+    "packageManager": "npm@11.16.0",
+    "engines": {
+        "node": "^24.0.0",
+        "npm": ">=10.0.0"
+    },
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION

Pin and align Node/npm versions across all environments and switch CI to `npm ci` for reproducible lockfile installs.

**What changed:**
- Set `nodejs_version: 24` in `.ddev/config.yaml` (was commented out, defaulting to Node 22)
- Switched Docker asset stage from `node:26-alpine` to `node:24-alpine` in `Dockerfile`
- Changed `npm install` to `npm ci` in CI workflow for deterministic dependency resolution
- Added `engines` (`node ^24.0.0`, `npm >=10.0.0`) and `packageManager` (`npm@11.16.0`) to `package.json`
- Created `.npmrc` with `engine-strict=true` to fail loudly on unsupported runtimes
- Updated README requirements to specify Node 24 LTS

**Why:** CI used Node 24 with `npm install`, Docker used Node 26, and DDEV had no explicit Node version — creating risk of lockfile drift and inconsistent asset builds across environments.

Fixes #366
