### PR TITLE
build: Bump Node.js 24 to 26 across all environments

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -98,7 +98,7 @@ web_extra_exposed_ports:
 # Alternatively, an explicit Composer version may be specified, for example "2.2.18".
 # To reinstall Composer after the image was built, run "ddev debug rebuild".
 
-nodejs_version: "24"
+nodejs_version: "26"
 # change from the default system Node.js version to any other version.
 # See https://docs.ddev.com/en/stable/users/configuration/config/#nodejs_version for more information
 # and https://www.npmjs.com/package/n#specifying-nodejs-versions for the full documentation,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Configure Node
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 26
           cache: 'npm'
       - name: Installing Node dependencies
         run: npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ############################################
 # Stage 1: Build frontend assets
 ############################################
-FROM node:24-alpine AS assets
+FROM node:26-alpine AS assets
 WORKDIR /app
 
 # Copy package files for better layer caching

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ FreshGuard is built with modern, battle-tested technologies designed for reliabi
 
 - PHP 8.5+
 - Composer
-- Node.js 24 LTS & npm 10+ (for frontend assets)
+- Node.js 26 (Current, becomes LTS Oct 2026) & npm 11+ (for frontend assets)
 - MariaDB
 
 ### Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "html",
+    "name": "freshguard",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -11,6 +11,10 @@
                 "laravel-vite-plugin": "^3.1.3",
                 "tailwindcss": "^4.3.3",
                 "vite": "^8.1.5"
+            },
+            "engines": {
+                "node": "^26.0.0",
+                "npm": ">=11.0.0"
             }
         },
         "node_modules/@emnapi/core": {
@@ -219,9 +223,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -239,9 +240,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -259,9 +257,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -279,9 +274,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -299,9 +291,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -319,9 +308,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -423,13 +409,6 @@
                 "source-map-js": "^1.2.1",
                 "tailwindcss": "4.3.3"
             }
-        },
-        "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-            "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@tailwindcss/oxide": {
             "version": "4.3.3",
@@ -548,9 +527,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -568,9 +544,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -588,9 +561,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -608,9 +578,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -764,13 +731,6 @@
             "peerDependencies": {
                 "vite": "^5.2.0 || ^6 || ^7 || ^8"
             }
-        },
-        "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-            "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "$schema": "https://json.schemastore.org/package.json",
     "packageManager": "npm@11.16.0",
     "engines": {
-        "node": "^24.0.0",
-        "npm": ">=10.0.0"
+        "node": "^26.0.0",
+        "npm": ">=11.0.0"
     },
     "private": true,
     "type": "module",


### PR DESCRIPTION

Update Node.js from 24 to 26 in all environments for consistency:

- `package.json` engines: `^26.0.0`, npm `>=11.0.0`
- `Dockerfile`: `node:26-alpine` for the assets build stage
- `.ddev/config.yaml`: `nodejs_version: \"26\"`
- `.github/workflows/ci.yml`: `node-version: 26`
- `README.md`: reflect Node 26 requirement
- `package-lock.json`: regenerated via `npm install`

Node 26 (Current release, becomes Active LTS Oct 2026) is fully
compatible with the project's dev tooling — Vite 8, Tailwind 4,
and npm 11 all declare `node >=22.12.0` in their engines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project’s supported Node.js version to 26.
  - Updated the minimum required npm version to 11.
  - Build, development, and continuous integration environments now use Node.js 26.

- **Documentation**
  - Updated setup requirements to reflect Node.js 26 and npm 11+.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->