### PR TITLE
fix(dependabot): Remove invalid /docker Dependabot target

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/docker"
-    schedule:
-      interval: "weekly"
+


### PR DESCRIPTION
Remove the Dependabot entry for `/docker` — that directory does not exist in this repository, so it can never discover a manifest. The root Dockerfile entry (`/`) already covers Docker updates.

Closes #363

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update configuration for Docker files.
  * Dependency update checks continue to run weekly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->