### PR TITLE
chore(cleanup): Remove stale Item model and Filament artifacts after batch refactor

### DIFF
--- a/app/Filament/Resources/Items/Pages/EditItem.php
+++ b/app/Filament/Resources/Items/Pages/EditItem.php
@@ -6,8 +6,6 @@ namespace App\Filament\Resources\Items\Pages;
 
 use App\Filament\Resources\Items\ItemResource;
 use Filament\Actions\DeleteAction;
-use Filament\Actions\ForceDeleteAction;
-use Filament\Actions\RestoreAction;
 use Filament\Resources\Pages\Concerns\HasRelationManagers;
 use Filament\Resources\Pages\EditRecord;
 
@@ -21,8 +19,6 @@ class EditItem extends EditRecord
     {
         return [
             DeleteAction::make(),
-            ForceDeleteAction::make(),
-            RestoreAction::make(),
         ];
     }
 

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Database\Factories\ItemFactory;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -23,10 +22,6 @@ use Illuminate\Support\Carbon;
  * @property Carbon $created_at
  * @property Carbon|null $updated_at
  * @property-read Collection<int, Batch> $batches
- *
- * @method static Builder<static> withBatchesExpiringWithinDays(int $days)
- *
- * @mixin Builder<static>
  **/
 class Item extends Model
 {

--- a/tests/Unit/Models/ItemTest.php
+++ b/tests/Unit/Models/ItemTest.php
@@ -120,5 +120,3 @@ test('can have many batches', function () {
         expect($item->batches->contains($batch))->toBeTrue();
     }
 });
-
-// ---- Tests below this line were removed as the application no longer has the 'withBatchesExpiringWithinDays' scope ----


### PR DESCRIPTION

Remove stale artifacts left behind after the batch refactor:

- **Item.php:** Remove nonexistent `withBatchesExpiringWithinDays` scope annotation and unused `Builder` import. The scope was removed during the batch refactor.
- **EditItem.php:** Remove `ForceDeleteAction` and `RestoreAction` — Item does not use soft deletes, so these actions are unsupported and misleading.
- **ItemTest.php:** Remove obsolete removal marker comment.

Closes #355
