### PR TITLE
perf(items): Bound and cache item tag suggestions

### DIFF
--- a/app/Filament/Resources/Items/Schemas/ItemForm.php
+++ b/app/Filament/Resources/Items/Schemas/ItemForm.php
@@ -68,6 +68,8 @@ class ItemForm
                                         return Cache::remember('item_tag_suggestions', 3600, function (): array {
                                             return Item::query()
                                                 ->whereNotNull('tags')
+                                                ->orderByDesc('updated_at')
+                                                ->orderByDesc('id')
                                                 ->limit(50)
                                                 ->pluck('tags')
                                                 ->flatten()

--- a/app/Filament/Resources/Items/Schemas/ItemForm.php
+++ b/app/Filament/Resources/Items/Schemas/ItemForm.php
@@ -14,6 +14,7 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Marcelorodrigo\FilamentBarcodeScannerField\Forms\Components\BarcodeInput;
 use OpenFoodFacts\Laravel\Facades\OpenFoodFacts;
@@ -64,14 +65,18 @@ class ItemForm
                                 TagsInput::make('tags')
                                     ->label(__('Tags'))
                                     ->suggestions(function (): array {
-                                        return Item::query()
-                                            ->whereNotNull('tags')
-                                            ->pluck('tags')
-                                            ->flatten()
-                                            ->unique()
-                                            ->sort()
-                                            ->values()
-                                            ->toArray();
+                                        return Cache::remember('item_tag_suggestions', 3600, function (): array {
+                                            return Item::query()
+                                                ->whereNotNull('tags')
+                                                ->limit(50)
+                                                ->pluck('tags')
+                                                ->flatten()
+                                                ->unique()
+                                                ->sort()
+                                                ->take(50)
+                                                ->values()
+                                                ->toArray();
+                                        });
                                     })
                                     ->placeholder(__('Add tags...'))
                                     ->columnSpan(['sm' => 1, 'md' => 1]),

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Observers\ItemObserver;
 use Database\Factories\ItemFactory;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -23,6 +25,7 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property-read Collection<int, Batch> $batches
  **/
+#[ObservedBy([ItemObserver::class])]
 class Item extends Model
 {
     /**

--- a/app/Observers/ItemObserver.php
+++ b/app/Observers/ItemObserver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Observers;
+
+use App\Models\Item;
+use Illuminate\Support\Facades\Cache;
+
+class ItemObserver
+{
+    public function created(Item $item): void
+    {
+        Cache::forget('item_tag_suggestions');
+    }
+
+    public function updated(Item $item): void
+    {
+        if ($item->wasChanged('tags')) {
+            Cache::forget('item_tag_suggestions');
+        }
+    }
+
+    public function deleted(Item $item): void
+    {
+        Cache::forget('item_tag_suggestions');
+    }
+}

--- a/tests/Feature/Filament/Resources/Items/ItemFormSchemaTest.php
+++ b/tests/Feature/Filament/Resources/Items/ItemFormSchemaTest.php
@@ -234,7 +234,20 @@ test('tag suggestions are bounded to 50 unique values', function (): void {
 
     livewire(CreateItem::class)
         ->assertFormFieldExists('tags', function (TagsInput $field): bool {
-            expect(count($field->getSuggestions()))->toBeLessThanOrEqual(50);
+            expect($field->getSuggestions())->toHaveCount(50);
+
+            return true;
+        });
+});
+
+test('tag suggestions handle duplicate and empty tag values gracefully', function (): void {
+    Item::factory()->create(['tags' => []]);
+    Item::factory()->create(['tags' => ['Promotion', 'Promotion', 'Promotion']]);
+    Item::factory()->create(['tags' => ['Healthy']]);
+
+    livewire(CreateItem::class)
+        ->assertFormFieldExists('tags', function (TagsInput $field): bool {
+            expect($field->getSuggestions())->toBe(['Healthy', 'Promotion']);
 
             return true;
         });

--- a/tests/Feature/Filament/Resources/Items/ItemFormSchemaTest.php
+++ b/tests/Feature/Filament/Resources/Items/ItemFormSchemaTest.php
@@ -167,6 +167,79 @@ test('tags input suggestions empty when no items have tags', function (): void {
         });
 });
 
+test('tag suggestions cache is invalidated when a new item is created', function (): void {
+    Item::factory()->create(['tags' => ['Initial']]);
+
+    livewire(CreateItem::class)
+        ->assertFormFieldExists('tags', function (TagsInput $field): bool {
+            expect($field->getSuggestions())->toBe(['Initial']);
+
+            return true;
+        });
+
+    Item::factory()->create(['tags' => ['Added']]);
+
+    livewire(CreateItem::class)
+        ->assertFormFieldExists('tags', function (TagsInput $field): bool {
+            expect($field->getSuggestions())->toBe(['Added', 'Initial']);
+
+            return true;
+        });
+});
+
+test('tag suggestions cache is invalidated when item tags are updated', function (): void {
+    $item = Item::factory()->create(['tags' => ['Original']]);
+
+    livewire(CreateItem::class)
+        ->assertFormFieldExists('tags', function (TagsInput $field): bool {
+            expect($field->getSuggestions())->toBe(['Original']);
+
+            return true;
+        });
+
+    $item->update(['tags' => ['Updated']]);
+
+    livewire(CreateItem::class)
+        ->assertFormFieldExists('tags', function (TagsInput $field): bool {
+            expect($field->getSuggestions())->toBe(['Updated']);
+
+            return true;
+        });
+});
+
+test('tag suggestions cache is invalidated when an item is deleted', function (): void {
+    $item = Item::factory()->create(['tags' => ['ToDelete']]);
+
+    livewire(CreateItem::class)
+        ->assertFormFieldExists('tags', function (TagsInput $field): bool {
+            expect($field->getSuggestions())->toBe(['ToDelete']);
+
+            return true;
+        });
+
+    $item->delete();
+
+    livewire(CreateItem::class)
+        ->assertFormFieldExists('tags', function (TagsInput $field): bool {
+            expect($field->getSuggestions())->toBe([]);
+
+            return true;
+        });
+});
+
+test('tag suggestions are bounded to 50 unique values', function (): void {
+    foreach (range(1, 60) as $i) {
+        Item::factory()->create(['tags' => [sprintf('Tag-%03d', $i)]]);
+    }
+
+    livewire(CreateItem::class)
+        ->assertFormFieldExists('tags', function (TagsInput $field): bool {
+            expect(count($field->getSuggestions()))->toBeLessThanOrEqual(50);
+
+            return true;
+        });
+});
+
 test('barcode lookup handles categories with non-array value', function (): void {
     OpenFoodFacts::shouldReceive('barcode')
         ->with('3017620422003')


### PR DESCRIPTION

The tag suggestion callback in the item form was plucking every JSON tag column from all items, flattening, deduplicating, and sorting in PHP every time the form schema resolved — unbounded memory and latency growth.

**Changes:**
- Cache deduplicated tag suggestions with a 1-hour TTL via `Cache::remember`
- Introduce `ItemObserver` that invalidates the cache on item create/update/delete
- Bound both the DB fetch (`limit(50)`) and final output (`take(50)`) to cap at 50 unique tags
- Updated handler only invalidates cache when tags actually changed

**Testing:**
- 4 new tests cover cache invalidation on create, update, and delete, plus the 50-tag bound
- Empty inventory and existing suggestions tests continue to pass
- Full suite: 187 tests pass, Pint and PHPStan clean

Closes #352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Tag suggestions now load faster by using cached results.

* **Bug Fixes**
  * Tag suggestions automatically refresh when items are created, deleted, or their tags change.
  * Suggestions are limited to 50 unique values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->