### PR TITLE
refactor(test): use LazilyRefreshDatabase in database tests

### DIFF
--- a/tests/Feature/Filament/Pages/QuickConsumeTest.php
+++ b/tests/Feature/Filament/Pages/QuickConsumeTest.php
@@ -7,12 +7,12 @@ use App\Models\Batch;
 use App\Models\Item;
 use App\Models\Location;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Str;
 
 use function Pest\Livewire\livewire;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 beforeEach(function (): void {
     $this->actingAs(User::factory()->create());

--- a/tests/Feature/Filament/Resources/Items/BatchesRelationManagerTest.php
+++ b/tests/Feature/Filament/Resources/Items/BatchesRelationManagerTest.php
@@ -11,12 +11,12 @@ use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\Testing\TestAction;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Carbon;
 
 use function Pest\Livewire\livewire;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 test('can render relation manager with batches', function (): void {
     $item = Item::factory()->create();

--- a/tests/Feature/Filament/Resources/Items/EditItemPageTest.php
+++ b/tests/Feature/Filament/Resources/Items/EditItemPageTest.php
@@ -7,11 +7,11 @@ use App\Filament\Resources\Items\RelationManagers\BatchesRelationManager;
 use App\Models\Item;
 use App\Models\Location;
 use Filament\Actions\DeleteAction;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 
 use function Pest\Livewire\livewire;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 test('can load page with correct form data', function (): void {
     $location = Location::factory()->create();

--- a/tests/Feature/Filament/Resources/Items/ItemFormSchemaTest.php
+++ b/tests/Feature/Filament/Resources/Items/ItemFormSchemaTest.php
@@ -6,12 +6,12 @@ use App\Filament\Resources\Items\Pages\CreateItem;
 use App\Models\Item;
 use App\Models\User;
 use Filament\Forms\Components\TagsInput;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use OpenFoodFacts\Laravel\Facades\OpenFoodFacts;
 
 use function Pest\Livewire\livewire;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 beforeEach(function (): void {
     $this->actingAs(User::factory()->create());

--- a/tests/Feature/Filament/Resources/Items/ItemResourceTest.php
+++ b/tests/Feature/Filament/Resources/Items/ItemResourceTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 use App\Filament\Resources\Items\Pages\ManageItems;
 use App\Models\Item;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Str;
 
 use function Pest\Livewire\livewire;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 test('can render page and see table records', function (): void {
     $items = Item::factory()->count(5)->create();

--- a/tests/Feature/Filament/Resources/Locations/LocationResourceTest.php
+++ b/tests/Feature/Filament/Resources/Locations/LocationResourceTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 use App\Filament\Resources\Locations\Pages\ManageLocations;
 use App\Models\Location;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase;
 use Illuminate\Support\Str;
 
 use function Pest\Livewire\livewire;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 test('can render page and see table records', function (): void {
     $parent = Location::factory()->create(['name' => 'Parent Location']);

--- a/tests/Feature/Filament/Resources/Users/UserResourceTest.php
+++ b/tests/Feature/Filament/Resources/Users/UserResourceTest.php
@@ -7,13 +7,13 @@ use App\Models\User;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Auth\Events\Registered;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Notification;
 
 use function Pest\Livewire\livewire;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 beforeEach(function (): void {
     // Authenticate as admin for all tests

--- a/tests/Feature/Filament/Widgets/RecentlyExpiredTest.php
+++ b/tests/Feature/Filament/Widgets/RecentlyExpiredTest.php
@@ -7,12 +7,12 @@ use App\Models\Batch;
 use App\Models\Item;
 use App\Models\Location;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Carbon;
 
 use function Pest\Livewire\livewire;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 beforeEach(function (): void {
     $this->actingAs(User::factory()->create());

--- a/tests/Unit/Http/Requests/ItemRequestTest.php
+++ b/tests/Unit/Http/Requests/ItemRequestTest.php
@@ -3,11 +3,11 @@
 declare(strict_types=1);
 
 use App\Http\Requests\ItemRequest;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 test('validation passes with valid data', function () {
     $request = new ItemRequest;

--- a/tests/Unit/Http/Requests/LocationRequestTest.php
+++ b/tests/Unit/Http/Requests/LocationRequestTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 use App\Http\Requests\LocationRequest;
 use App\Models\Location;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 test('validation passes with valid data', function () {
     $request = new LocationRequest;

--- a/tests/Unit/Http/Requests/StoreBatchRequestTest.php
+++ b/tests/Unit/Http/Requests/StoreBatchRequestTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 use App\Http\Requests\StoreBatchRequest;
 use App\Models\Item;
 use App\Models\Location;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Validator;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 $request = null;
 

--- a/tests/Unit/Http/Requests/UpdateBatchRequestTest.php
+++ b/tests/Unit/Http/Requests/UpdateBatchRequestTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 use App\Http\Requests\UpdateBatchRequest;
 use App\Models\Item;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Validator;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 $request = null;
 

--- a/tests/Unit/Models/BatchTest.php
+++ b/tests/Unit/Models/BatchTest.php
@@ -5,10 +5,10 @@ namespace Tests\Unit\Models;
 use App\Models\Batch;
 use App\Models\Item;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Carbon;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 test('it uses uuids as primary key', function () {
     $batch = Batch::factory()->create();

--- a/tests/Unit/Models/ItemTest.php
+++ b/tests/Unit/Models/ItemTest.php
@@ -6,10 +6,10 @@ use App\Models\Batch;
 use App\Models\Item;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Str;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 test('uuid is generated on creation', function () {
     $item = Item::factory()->create();

--- a/tests/Unit/Models/LocationTest.php
+++ b/tests/Unit/Models/LocationTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tests\Unit\Models;
 
 use App\Models\Location;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Str;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 test('it can create a location with factory', function () {
     $location = Location::factory()->create();

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Tests\Unit\Models;
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 test('it can create a user with factory', function () {
     $user = User::factory()->create();

--- a/tests/Unit/Policies/UserPolicyTest.php
+++ b/tests/Unit/Policies/UserPolicyTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 use App\Models\User;
 use App\Policies\UserPolicy;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 
-uses(RefreshDatabase::class);
+uses(LazilyRefreshDatabase::class);
 
 beforeEach(function (): void {
     $this->policy = new UserPolicy;


### PR DESCRIPTION
Swap `RefreshDatabase` for `LazilyRefreshDatabase` in all 17 database-backed Pest test files.

`LazilyRefreshDatabase` defers migration and transaction setup until a test actually begins a transaction or executes a query, so tests that never touch the database (e.g. `SmokeTest`, validation-only request tests) skip that setup entirely. Isolation is unchanged: every test still runs inside a transaction rolled back on teardown.

Verification (local DDEV environment):
- Full suite: 188 passed (639 assertions), runtime ~10.5s -> ~7.8s
- `ddev composer pint:dirty`: no fixes needed
- `ddev composer phpstan`: no errors

Related to #371. The original issue also proposes centralizing the trait in `tests/Pest.php` and removing the repeated per-file declarations; that part is intentionally deferred, so this PR does not close the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved database setup efficiency across feature and unit test suites.
  * Preserved existing test coverage and validation behavior while maintaining database isolation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->