### PR TITLE
test(users): consolidate admin registration tests

### DIFF
--- a/tests/Feature/Filament/Resources/Users/UserResourceTest.php
+++ b/tests/Feature/Filament/Resources/Users/UserResourceTest.php
@@ -224,26 +224,7 @@ test('admin can access user management page', function (): void {
         ->assertSuccessful();
 });
 
-test('first registered user becomes admin automatically', function (): void {
-    Notification::fake();
-
-    // Clear any existing users
-    User::query()->delete();
-
-    $userData = [
-        'name' => 'First User',
-        'email' => 'first@example.com',
-        'password' => 'password',
-    ];
-
-    $user = User::create($userData);
-    event(new Registered($user));
-
-    $user->refresh();
-    expect($user->is_admin)->toBeTrue();
-});
-
-test('second registered user is not automatically admin', function (): void {
+test('first registered user becomes admin and subsequent users do not', function (): void {
     Notification::fake();
 
     User::query()->delete();
@@ -255,15 +236,20 @@ test('second registered user is not automatically admin', function (): void {
     ]);
     event(new Registered($firstUser));
 
+    $firstUser->refresh();
+    expect($firstUser->is_admin)->toBeTrue();
+
     $secondUser = User::create([
         'name' => 'Second User',
         'email' => 'second@example.com',
         'password' => 'password',
     ]);
-    event(new Illuminate\Auth\Events\Registered($secondUser));
+    event(new Registered($secondUser));
 
+    $firstUser->refresh();
     $secondUser->refresh();
-    expect($secondUser->is_admin)->toBeFalse();
+    expect($firstUser->is_admin)->toBeTrue()
+        ->and($secondUser->is_admin)->toBeFalse();
 });
 
 test('admin cannot delete themselves', function (): void {


### PR DESCRIPTION

Consolidate two separate tests for first and second user admin status into a single test that verifies both behaviors in sequence.

Previously, there were separate tests for 'first registered user becomes admin' and 'second registered user is not admin'. These tests had overlapping setup and could be logically grouped together to reduce duplication.

The new test verifies that after the first user registers and becomes admin, the second user does not become admin, all within a single test case.

Closes #374
