### PR TITLE
fix(php): add declare(strict_types=1) to remaining noncompliant files

### DIFF
--- a/app/Filament/Resources/Locations/LocationResource.php
+++ b/app/Filament/Resources/Locations/LocationResource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Filament\Resources\Locations;
 
 use App\Filament\Resources\Locations\Pages\ManageLocations;

--- a/app/Filament/Resources/Locations/Pages/ManageLocations.php
+++ b/app/Filament/Resources/Locations/Pages/ManageLocations.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Filament\Resources\Locations\Pages;
 
 use App\Filament\Resources\Locations\LocationResource;

--- a/app/Filament/Resources/Locations/Tables/LocationsTable.php
+++ b/app/Filament/Resources/Locations/Tables/LocationsTable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Filament\Resources\Locations\Tables;
 
 use Filament\Actions\BulkActionGroup;

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 abstract class Controller

--- a/app/Http/Requests/LocationRequest.php
+++ b/app/Http/Requests/LocationRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests;
 
 use Illuminate\Contracts\Validation\ValidationRule;

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use Database\Factories\LocationFactory;

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 


### PR DESCRIPTION

Add strict type declarations to the 7 tracked PHP files that were missing them: Location model, LocationResource, ManageLocations, LocationsTable, Controller, LocationRequest, and public/index.php.

Blade templates and generated/cache files are excluded as invalid for top-level declarations. All existing checks pass (pint, phpstan, 193 tests).

Closes #369


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enabled strict type checking across key application components.
  * Improves consistency and helps detect type-related issues earlier during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->