### PR TITLE
fix(docker): restrict PR builds to verification-only and enable stale tag cleanup

### DIFF
--- a/.github/workflows/docker-scheduled-cleanup.yml
+++ b/.github/workflows/docker-scheduled-cleanup.yml
@@ -20,5 +20,6 @@ jobs:
           organization: marcelorodrigo
           repositories: freshguard
           pr-retention-days: 30
-          dry-run: true
+          sha-retention-days: 36500
+          dry-run: false
           verbose: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,6 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-      packages: write
       pull-requests: write
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
@@ -94,6 +93,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
@@ -167,6 +167,7 @@ jobs:
         run: docker rm -f freshguard-smoke 2>/dev/null || true
 
       - name: Build and push multi-platform manifest
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -188,11 +189,10 @@ jobs:
 
             let updateComment;
             if (buildSuccess) {
-              updateComment = `✅ Docker image published!
+              updateComment = `✅ Docker build succeeded!
 
-              **Image:** \`marcelorodrigo/freshguard:${{ steps.tag.outputs.tag }}\`
-              **Platforms:** linux/amd64, linux/arm64
-              **Status:** Smoke tests passed, image published`;
+              **Tag:** \`marcelorodrigo/freshguard:${{ steps.tag.outputs.tag }}\`
+              **Status:** Smoke tests passed, image built but not published (verification only)`;
             } else {
               updateComment = `❌ Docker build failed!
 


### PR DESCRIPTION
## Summary

- **docker.yml:** PR builds no longer log in to Docker Hub or push multi-platform manifests. Images are built and smoke-tested locally only.
- **docker.yml:** Removed unused `packages: write` permission.
- **docker.yml:** Updated PR comment to clarify images are built but not published.
- **docker-scheduled-cleanup.yml:** Enabled live deletion (`dry-run: false`) with 30-day retention.
- **docker-scheduled-cleanup.yml:** Set `sha-retention-days: 36500` to preserve SHA tags indefinitely.

## Closes

- Closes #357 (restrict Docker publication to trusted, CI-green events)
- Closes #358 (enable and verify scheduled deletion of stale Docker PR tags)

## Verification

- PR builds will still run smoke tests (health, queue worker, scheduler).
- Only master pushes, version tags, releases, and manual dispatch will publish to Docker Hub.
- The weekly cleanup cron will now delete PR tags older than 30 days.