### PR TITLE
fix(locations): prevent unsafe deletion with inventory

### DIFF
--- a/app/Actions/DeleteLocations.php
+++ b/app/Actions/DeleteLocations.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\Batch;
+use App\Models\Location;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+final class DeleteLocations
+{
+    /**
+     * Delete locations when every selected location is eligible.
+     *
+     * @param  Collection<int, Location>  $locations
+     */
+    public function __invoke(Collection $locations): bool
+    {
+        $locationIds = $locations
+            ->map(static fn (Location $location): string => $location->id)
+            ->unique()
+            ->values()
+            ->all();
+
+        if ($locationIds === []) {
+            return true;
+        }
+
+        DB::beginTransaction();
+
+        try {
+            $lockedLocations = Location::query()
+                ->whereKey($locationIds)
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get();
+
+            if ($lockedLocations->count() !== count($locationIds)) {
+                $this->rollBack();
+
+                return false;
+            }
+
+            if (Batch::query()->whereIn('location_id', $locationIds)->exists()) {
+                $this->rollBack();
+
+                return false;
+            }
+
+            foreach ($lockedLocations as $location) {
+                if ($location->delete()) {
+                    continue;
+                }
+
+                $this->rollBack();
+
+                return false;
+            }
+
+            DB::commit();
+
+            return true;
+        } catch (QueryException $exception) {
+            $this->rollBack();
+
+            if ($this->isLocationForeignKeyViolation($exception)) {
+                return false;
+            }
+
+            throw $exception;
+        } catch (Throwable $exception) {
+            $this->rollBack();
+
+            throw $exception;
+        }
+    }
+
+    private function isLocationForeignKeyViolation(QueryException $exception): bool
+    {
+        $errorCode = $exception->errorInfo[1] ?? null;
+
+        return $exception->getCode() === '23000'
+            && ($errorCode === 1451 || $errorCode === '1451');
+    }
+
+    private function rollBack(): void
+    {
+        if (DB::transactionLevel() > 0) {
+            DB::rollBack();
+        }
+    }
+}

--- a/app/Filament/Resources/Locations/Tables/LocationsTable.php
+++ b/app/Filament/Resources/Locations/Tables/LocationsTable.php
@@ -4,18 +4,23 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\Locations\Tables;
 
+use App\Actions\DeleteLocations;
+use App\Models\Location;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 
 class LocationsTable
 {
     public static function configure(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->withExists('batches'))
             ->contentGrid([
                 'sm' => 1,
                 'md' => 1,
@@ -42,11 +47,37 @@ class LocationsTable
             ])
             ->recordActions([
                 EditAction::make(),
-                DeleteAction::make(),
+                DeleteAction::make()
+                    ->disabled(fn (Location $record): bool => (bool) $record->getAttribute('batches_exists'))
+                    ->tooltip(fn (Location $record): ?string => $record->getAttribute('batches_exists')
+                        ? (string) __('filament.locations.delete.disabled_tooltip')
+                        : null)
+                    ->modalDescription(__('filament.locations.delete.modal_description'))
+                    ->failureNotificationTitle(__('filament.locations.delete.blocked_title'))
+                    ->failureNotificationBody(__('filament.locations.delete.blocked_body'))
+                    ->using(
+                        static fn (Location $record): bool => (new DeleteLocations)(new Collection([$record]))
+                    ),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->modalDescription(__('filament.locations.delete.bulk_modal_description'))
+                        ->failureNotificationTitle(__('filament.locations.delete.bulk_blocked_title'))
+                        ->using(static function (Collection $records, DeleteBulkAction $action): void {
+                            $deleted = (new DeleteLocations)($records);
+
+                            if (! $deleted) {
+                                $action->reportCompleteBulkProcessingFailure(
+                                    'location_contains_batches',
+                                    __('filament.locations.delete.bulk_blocked_body'),
+                                );
+
+                                return;
+                            }
+
+                            $action->reportBulkProcessingSuccessfulRecordsCount($records->count());
+                        }),
                 ]),
             ]);
     }

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -46,6 +46,13 @@ class Location extends Model
         'parent_id',
     ];
 
+    protected static function booted(): void
+    {
+        static::deleting(function (Location $location): bool {
+            return ! $location->hasBatches();
+        });
+    }
+
     /**
      * Get the parent location.
      *
@@ -77,5 +84,13 @@ class Location extends Model
     {
         /** @var HasMany<Batch, Location> */
         return $this->hasMany(Batch::class, 'location_id');
+    }
+
+    /**
+     * Determine whether this location contains batches.
+     */
+    public function hasBatches(): bool
+    {
+        return $this->batches()->exists();
     }
 }

--- a/lang/en/filament.php
+++ b/lang/en/filament.php
@@ -7,4 +7,15 @@ return [
         'quick_consume' => 'Quick Consume',
         'inventory' => 'Inventory',
     ],
+    'locations' => [
+        'delete' => [
+            'blocked_title' => 'Location cannot be deleted',
+            'blocked_body' => 'This location contains inventory. Remove all batches before deleting it.',
+            'bulk_blocked_title' => 'Locations were not deleted',
+            'bulk_blocked_body' => 'No locations were deleted because at least one selected location contains inventory.',
+            'disabled_tooltip' => 'Locations containing inventory cannot be deleted.',
+            'modal_description' => 'Child locations will be kept and become root locations.',
+            'bulk_modal_description' => 'This deletion is atomic: if any selected location contains inventory, no locations will be deleted. Child locations will be kept and become root locations.',
+        ],
+    ],
 ];

--- a/tests/Feature/Filament/Resources/Locations/LocationResourceTest.php
+++ b/tests/Feature/Filament/Resources/Locations/LocationResourceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Filament\Resources\Locations\Pages\ManageLocations;
+use App\Models\Batch;
 use App\Models\Location;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase;
@@ -142,4 +143,50 @@ test('can bulk delete locations', function (): void {
     foreach ($locations as $location) {
         expect(Location::find($location->id))->toBeNull();
     }
+});
+
+test('disables deletion for a location with batches', function (): void {
+    $location = Location::factory()->create();
+    Batch::factory()->for($location)->create();
+
+    livewire(ManageLocations::class)
+        ->assertTableActionDisabled('delete', $location);
+
+    expect(Location::find($location->id))->not->toBeNull();
+});
+
+test('does not delete populated locations in bulk', function (): void {
+    $location = Location::factory()->create();
+    Batch::factory()->for($location)->create();
+
+    livewire(ManageLocations::class)
+        ->callTableBulkAction('delete', collect([$location]))
+        ->assertNotified();
+
+    expect(Location::find($location->id))->not->toBeNull();
+});
+
+test('rejects mixed bulk deletion atomically', function (): void {
+    $emptyLocation = Location::factory()->create();
+    $populatedLocation = Location::factory()->create();
+    Batch::factory()->for($populatedLocation)->create();
+
+    livewire(ManageLocations::class)
+        ->callTableBulkAction('delete', collect([$emptyLocation, $populatedLocation]))
+        ->assertNotified();
+
+    expect(Location::find($emptyLocation->id))->not->toBeNull()
+        ->and(Location::find($populatedLocation->id))->not->toBeNull();
+});
+
+test('keeps children as root locations when deleting a parent', function (): void {
+    $parent = Location::factory()->create();
+    $child = Location::factory()->create(['parent_id' => $parent->id]);
+
+    livewire(ManageLocations::class)
+        ->callTableAction('delete', $parent)
+        ->assertNotified();
+
+    expect(Location::find($parent->id))->toBeNull()
+        ->and($child->fresh()?->parent_id)->toBeNull();
 });

--- a/tests/Unit/Actions/DeleteLocationsTest.php
+++ b/tests/Unit/Actions/DeleteLocationsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Actions;
+
+use App\Actions\DeleteLocations;
+use App\Models\Batch;
+use App\Models\Location;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+
+uses(LazilyRefreshDatabase::class);
+
+test('it treats an empty collection as a successful no-op', function (): void {
+    expect((new DeleteLocations)(new Collection))->toBeTrue();
+});
+
+test('it deletes empty locations', function (): void {
+    $locations = Location::factory()->count(2)->create();
+
+    expect((new DeleteLocations)($locations))->toBeTrue();
+    expect(Location::query()->whereKey($locations->modelKeys())->exists())->toBeFalse();
+});
+
+test('it rejects a populated location without deleting it', function (): void {
+    $location = Location::factory()->create();
+    Batch::factory()->for($location)->create();
+
+    expect((new DeleteLocations)(new Collection([$location])))->toBeFalse();
+    expect(Location::find($location->id))->not->toBeNull();
+});
+
+test('it rejects mixed selections atomically', function (): void {
+    $emptyLocation = Location::factory()->create();
+    $populatedLocation = Location::factory()->create();
+    Batch::factory()->for($populatedLocation)->create();
+
+    expect((new DeleteLocations)(new Collection([$emptyLocation, $populatedLocation])))->toBeFalse();
+    expect(Location::find($emptyLocation->id))->not->toBeNull()
+        ->and(Location::find($populatedLocation->id))->not->toBeNull();
+});
+
+test('it keeps children as root locations when deleting an empty parent', function (): void {
+    $parent = Location::factory()->create();
+    $child = Location::factory()->create(['parent_id' => $parent->id]);
+
+    expect((new DeleteLocations)(new Collection([$parent])))->toBeTrue();
+    expect(Location::find($parent->id))->toBeNull()
+        ->and($child->fresh()?->parent_id)->toBeNull();
+});

--- a/tests/Unit/Models/LocationTest.php
+++ b/tests/Unit/Models/LocationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Models;
 
+use App\Models\Batch;
 use App\Models\Location;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Str;
@@ -44,6 +45,23 @@ test('it can have no parent', function () {
 test('it can have no children', function () {
     $location = Location::factory()->create();
     expect($location->children)->toHaveCount(0);
+});
+
+test('it knows whether it has batches', function (): void {
+    $emptyLocation = Location::factory()->create();
+    $populatedLocation = Location::factory()->create();
+    Batch::factory()->for($populatedLocation)->create();
+
+    expect($emptyLocation->hasBatches())->toBeFalse()
+        ->and($populatedLocation->hasBatches())->toBeTrue();
+});
+
+test('it prevents direct deletion when it has batches', function (): void {
+    $location = Location::factory()->create();
+    Batch::factory()->for($location)->create();
+
+    expect($location->delete())->toBeFalse()
+        ->and(Location::find($location->id))->not->toBeNull();
 });
 
 test('fillable attributes', function () {


### PR DESCRIPTION
Prevent locations with inventory from being deleted through the Filament location management UI.\n\nThe change adds a transactional DeleteLocations action that validates every selected location before mutation, rejects mixed bulk selections atomically, and protects direct model deletion with a batch guard. Populated record actions are disabled with localized guidance, while bulk actions explain why no records were deleted. Existing child-location null-on-delete behavior remains unchanged and is documented in confirmation text.\n\nThe implementation uses the existing restrictive foreign key as a final safety boundary, translates only the expected MariaDB constraint failure, and rethrows unexpected database errors. This keeps the change focused on issue #341 without modifying migrations or adding dependencies.\n\nCloses #341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards preventing locations with associated batches from being deleted.
  * Added support for deleting multiple locations with all-or-nothing validation.
  * Child locations are promoted to root locations when their parent is deleted.
* **Bug Fixes**
  * Deletion failures now preserve affected records and provide clear feedback.
* **Localization**
  * Added messages and guidance for blocked and bulk location deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->